### PR TITLE
Move to tracing for logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monitord-exporter"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Cooper Ry Lees <me@cooperlees.com>"]
 license = "GPL-2.0-or-later"
 readme = "README.md"
@@ -14,12 +14,13 @@ categories = ["network-programming", "os::linux-apis"]
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.2", features = ["derive"] }
-clap-verbosity-flag = "2.0"
-env_logger = "0.10"
-log = "0.4"
-monitord = "0.4.1"
+monitord = "0.5.0"
 prometheus_exporter = "0.8.4"
 signal-hook = "0.3.14"
+tracing = "0.1"
+tracing-core = "0.1"
+tracing-glog = "0.3"
+tracing-subscriber = "0.3"
 
 [profile]
 release = { strip = "symbols", lto = "thin", opt-level = "z" }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Options:
 
           [default: unix:path=/run/dbus/system_bus_socket]
 
+  -l, --log-level <LOG_LEVEL>
+          Adjust the console log-level
+
+          [default: Info]
+          [possible values: error, warn, info, debug, trace]
+
   -n, --networkd-state-file-path <NETWORKD_STATE_FILE_PATH>
           network netif dir
 
@@ -33,17 +39,11 @@ Options:
 
           [default: 1]
 
-  -v, --verbose...
-          More output per occurrence
-
-  -q, --quiet...
-          Less output per occurrence
-
   -h, --help
-          Print help information (use `-h` for a summary)
+          Print help (see a summary with '-h')
 
   -V, --version
-          Print version information
+          Print version
 ```
 
 ## Example Output
@@ -166,8 +166,8 @@ monitord_units_total_units 584
 
 To do test runs (requires `systemd` and optionally `systemd-networkd` *installed*)
 
-- `cargo run -- -p 1234 -v`
-  - `-v` for debug logging
+- `cargo run -- -p 1234 -l debug`
+  - `-l` for logging level. Recommend debug when developing
   - `-p` > 1024 to run as non root / with capabilities
 
 Ensure the following pass before submitting a PR (CI checks):

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod logging;
+pub mod metrics;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,47 @@
+use std::io::stderr;
+use std::io::IsTerminal;
+
+use clap::ValueEnum;
+use tracing::debug;
+use tracing_glog::Glog;
+use tracing_glog::GlogFields;
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::fmt;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::Registry;
+
+// This enum can be used to add `log-level` option to CLI binaries.
+#[derive(ValueEnum, Clone, Debug, Copy)]
+pub enum LogLevels {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl From<LogLevels> for LevelFilter {
+    fn from(public_level: LogLevels) -> Self {
+        match public_level {
+            LogLevels::Error => LevelFilter::ERROR,
+            LogLevels::Warn => LevelFilter::WARN,
+            LogLevels::Info => LevelFilter::INFO,
+            LogLevels::Debug => LevelFilter::DEBUG,
+            LogLevels::Trace => LevelFilter::TRACE,
+        }
+    }
+}
+
+pub fn setup_logging(log_filter_level: LevelFilter) {
+    let fmt = fmt::Layer::default()
+        .with_writer(std::io::stderr)
+        .with_ansi(stderr().is_terminal())
+        .event_format(Glog::default().with_timer(tracing_glog::LocalTime::default()))
+        .fmt_fields(GlogFields::default())
+        .with_filter(log_filter_level);
+
+    let subscriber = Registry::default().with(fmt);
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("Unable to set global tracing subscriber");
+    debug!("Logging is setup with {:?} level", log_filter_level);
+}

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,5 +1,5 @@
-use log::debug;
 use prometheus_exporter::{self, prometheus::register_gauge_vec, prometheus::GaugeVec};
+use tracing::debug;
 
 #[derive(Debug)]
 struct NetworkdInterfaceStats {


### PR DESCRIPTION
- monitord has moved to it so we should too
- Let's use tracing_log to get prometheus exporter logs

Test:
- Run and see logs:
```
cooper@home1:~/repos/monitord-exporter$ cargo run -- -l debug -p 1234
D0815 02:19:22.726302 472653 src/logging.rs:46] Logging is setup with LevelFilter::DEBUG level
I0815 02:19:22.726440 472653 src/main.rs:56] Starting monitord-exporter on port 1234
D0815 02:19:22.726599 472653 :] Server listening on [::]:1234
```